### PR TITLE
PR: Bug fix for the History endpoint. chartByDay parameter is not currently sent

### DIFF
--- a/src/Services/History.service.ts
+++ b/src/Services/History.service.ts
@@ -62,6 +62,7 @@ export const history = async (
     chartLast: lastN,
     chartReset,
     chartSimplify,
+    chartByDay
   });
 
   return data.map((o: KVP) =>


### PR DESCRIPTION
Currently, the `chartByDay` parameter is not sent with the request payload. This results in incorrect data being returned.

When `range` is set to `"date"`, a `date` is specified, and `chartByDay` is `true`, OHLCV data should be returned. (see https://iexcloud.io/docs/api/#historical-prices). Currently intraday minute-bar data is sent back. 

I've added chartByDay into the request payload, and this service now behaves as expected. 

