### PR TITLE
Add Daily Treasury Rates endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,11 @@ Below is a list of the iexcloud APIs that have ([x]) and have not ([ ]) been imp
 | [x] | News
 | [ ] | Crypto
 
+### Treasuries
+|     | Endpoint       | Message Units | per |
+|-----|----------------|---------------:|-----|
+| [x] | Daily Treasury Rates | 1000 | per symbol per date
+
 ### Reference Data
 |     | Endpoint       | Message Units | per |
 |-----|----------------|---------------:|-----|

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Below is a list of the iexcloud APIs that have ([x]) and have not ([ ]) been imp
 | [x] | Cash Flow |             1000 |per symbol per period
 | [x] | Collections  |             1 |per symbol in  collection
 | [x] | Company  |                 1 |per symbol
+| [x] | CEO Compensation  |       20 |per symbol
 | [x] | Delayed Quote  |           1 |per symbol
 | [x] | Dividends  |              10 |per symbol
 | [x] | Earnings |              1000 |per symbol per period

--- a/USAGE.md
+++ b/USAGE.md
@@ -115,6 +115,8 @@ export declare const company: (symbol: string) => Promise<Company>;
 
 export declare const cryptoQuote: (symbol: string) => Promise<CryptoQuote>;
 
+export declare const dailyTreasuryRates: (symbol: string) => Promise<DailyTreasuryRate[]>;
+
 export declare const delayedQuote: (symbol: string) => Promise<DelayedQuote>;
 
 export declare type timePeriod = "next" | "1m" | "3m" | "6m" | "ytd" | "1y" | "2y" | "5y";
@@ -228,4 +230,3 @@ export declare const officialPrice: (symbol: string) => Promise<DEEPOfficialPric
 
 export declare const deepTrades: (symbol: string) => Promise<DEEPTrade[]>;
 ```
-

--- a/src/Services/DailyTreasuryRates.service.ts
+++ b/src/Services/DailyTreasuryRates.service.ts
@@ -1,0 +1,65 @@
+import { DynamicObject, iexApiRequest, KVP } from "./iexcloud.service";
+
+/**
+ * Daily Treasury Rates
+ * https://iexcloud.io/docs/api/#daily-treasury-rates
+ *
+ * Provides the time series data of daily constant maturity rate for treasuries.
+ *
+ * - Data Weigthing: 1000 per symbol per date
+ *
+ * @param symbol - a treasury symbol
+ * @returns array of records
+ *
+ */
+export const dailyTreasuryRates = async (
+  symbol: TreasurySymbolType
+): Promise<readonly IEXDailyTreasuryRate[]> => {
+  const dailyTreasuryRatesData: KVP = await iexApiRequest(
+    `/time-series/treasury/${symbol}`
+  );
+
+  return dailyTreasuryRatesData.map(
+    (o: KVP) =>
+      new DailyTreasuryRate({
+        symbol,
+        ...o,
+      })
+  );
+};
+
+export interface IEXDailyTreasuryRate {
+  /** Treasury Symbol */
+  readonly symbol: string;
+  /** Rate value of the treasury */
+  readonly value: number;
+  /** Id of the treasury */
+  readonly id: string;
+  /** Key of the treasury */
+  readonly key: string;
+  /** Sub key of the treasury */
+  readonly subkey: string;
+  /** Last updated time of the data point represented as millisecond epoch. */
+  readonly updated: number;
+}
+
+export class DailyTreasuryRate extends DynamicObject
+  implements IEXDailyTreasuryRate {
+  public symbol: string = "";
+  public value: number = 0;
+  public id: string = "";
+  public key: string = "";
+  public subkey: string = "";
+  public updated: number = 0;
+}
+
+export type TreasurySymbolType =
+  | "DGS30" //	30 Year constant maturity rate
+  | "DGS20" //	20 Year constant maturity rate
+  | "DGS10" //	10 Year constant maturity rate
+  | "DGS5" //	5 Year constant maturity rate
+  | "DGS2" //	2 Year constant maturity rate
+  | "DGS1" //	1 Year constant maturity rate
+  | "DGS6MO" //	6 Month constant maturity rate
+  | "DGS3MO" //	3 Month constant maturity rate
+  | "DGS1MO"; //	1 Month constant maturity rate

--- a/src/Services/History.service.ts
+++ b/src/Services/History.service.ts
@@ -62,7 +62,7 @@ export const history = async (
     chartLast: lastN,
     chartReset,
     chartSimplify,
-    chartByDay
+    chartByDay,
   });
 
   return data.map((o: KVP) =>

--- a/src/Tests/DailyTreasuryRates.test.ts
+++ b/src/Tests/DailyTreasuryRates.test.ts
@@ -1,0 +1,11 @@
+/**
+ * @jest-environment node
+ */
+
+import * as service from "../Services/DailyTreasuryRates.service";
+
+test("dailyTreasuryRates", async () => {
+  expect(await service.dailyTreasuryRates("DGS10")).toEqual(
+    expect.arrayContaining([expect.any(service.DailyTreasuryRate)])
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from "./Services/CeoCompensation.service";
 export * from "./Services/Collection.service";
 export * from "./Services/Company.service";
 export * from "./Services/CryptoQuote.service";
+export * from "./Services/DailyTreasuryRates.service";
 export * from "./Services/DEEPAuction.service";
 export * from "./Services/DEEPBook.service";
 export * from "./Services/DEEPOfficialPrice.service";


### PR DESCRIPTION
**Changes**

- Add [Daily Treasury Rates](https://iexcloud.io/docs/api/#daily-treasury-rates) endpoint
- Add Daily Treasury Rates test
- Add the `CEO Compensation` entry to the README

**Notes**

Hi @schardtbc! I'm adding this as part of the [Hacktoberfest](https://hacktoberfest.digitalocean.com/) effort 🍻🥨. In order for this PR to be accepted for the Hacktoberfest you would have to add the accepted label:

> An individual PR can be opted-in with a maintainer adding the "hacktoberfest-accepted" label to the PR.

If you can do that, I would highly appreciate it! 🤞🏼 Thanks