### PR TITLE
Add missing fields to IEXCompany

### DIFF
--- a/src/Services/Company.service.ts
+++ b/src/Services/Company.service.ts
@@ -1,6 +1,6 @@
 import { DynamicObject, iexApiRequest, KVP } from "./iexcloud.service";
 
-export const company = async (symbol: string): Promise<Company> => {
+export const company = async (symbol: string): Promise<IEXCompany> => {
   const data: KVP = await iexApiRequest(`/stock/${symbol}/company`);
 
   return new Company(data);
@@ -19,9 +19,16 @@ export interface IEXCompany {
   securityName: string | null;
   tags: string[];
   employees: number | null;
+  address: string;
+  address2: string;
+  city: string;
+  state: string;
+  zip: string;
+  country: string;
+  phone: string;
 }
 
-export class Company extends DynamicObject {
+export class Company extends DynamicObject implements IEXCompany {
   public symbol: string = "";
   public companyName: string = "";
   public CEO: string = "";
@@ -34,4 +41,11 @@ export class Company extends DynamicObject {
   public securityName: string = "";
   public tags: string[] = [];
   public employees: number = 0;
+  public address: string = "";
+  public address2: string = "";
+  public city: string = "";
+  public state: string = "";
+  public zip: string = "";
+  public country: string = "";
+  public phone: string = "";
 }

--- a/src/Tests/Company.test.ts
+++ b/src/Tests/Company.test.ts
@@ -1,0 +1,9 @@
+/**
+ * @jest-environment node
+ */
+
+import * as service from "../Services/Company.service";
+
+test("company", async () => {
+  expect(await service.company("AAPL")).toBeInstanceOf(service.Company);
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -31,9 +31,6 @@ test("book", async () => {
 test("ceoCompensation", async () => {
   expect(await iex.ceoCompensation("AAPL")).toBeInstanceOf(iex.CeoCompensation);
 });
-test("company", async () => {
-  expect(await iex.company("AAPL")).toBeInstanceOf(iex.Company);
-});
 // test("cryptoQuote", async () => {
 //   expect(await iex.cryptoQuote("BTC")).toBeInstanceOf(iex.CryptoQuote);
 // });


### PR DESCRIPTION
**Changes**

- Resolves #37:
  - Add missing types to IEXCompany
  - Create a separate `Company.test.ts` file for the Company service

**Notes**

Hi @schardtbc! I'm adding this as part of the [Hacktoberfest](https://hacktoberfest.digitalocean.com/) effort 🍻🥨. In order for this PR to be accepted for the Hacktoberfest you would have to add the designated label:

> An individual PR can be opted-in with a maintainer adding the "hacktoberfest-accepted" label to the PR.

If you can do that, I would highly appreciate it! 🤞🏼 Thanks