### PR TITLE
Fix OHLC test

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -162,7 +162,7 @@ test("news", async () => {
   );
 });
 test("ohlc", async () => {
-  expect(await iex.ohlc("AAPL")).toEqual(expect.any(iex.OHLC));
+  expect(await iex.ohlc("T")).toEqual(expect.any(iex.OHLC));
 });
 // test("peers", async () => {
 //   expect(await iex.peers("AAPL")).toEqual(


### PR DESCRIPTION
**Changes**

- Resolves #34:
  - For some reason calling the OHLC endpoint with `AAPL` returns empty data but for `T` it doesn't. I guess it might be because they are in different exchanges and/or as the docs describes: 

> Some stocks can report late open or close prices

**Notes**

Hi @schardtbc! I'm adding this as part of the [Hacktoberfest](https://hacktoberfest.digitalocean.com/) effort 🍻🥨. In order for this PR to be accepted for the Hacktoberfest you would have to add the designated label:

> An individual PR can be opted-in with a maintainer adding the "hacktoberfest-accepted" label to the PR.

If you can do that, I would highly appreciate it! 🤞🏼 Thanks